### PR TITLE
feat(config): Override config field name in tag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -96,8 +96,11 @@ func bindEnvs(v *viper.Viper, iface interface{}, parts ...string) error {
 	}
 	for i := 0; i < ift.NumField(); i++ {
 		val := ifv.Field(i)
-		// lowercase first character of field name `Log` => log
-		tv := lowerFirst(ift.Field(i).Name)
+		tv := ift.Field(i).Tag.Get("mapstructure")
+		if tv == "" {
+			// default to field name, with lowercased first char `Log` => log
+			tv = lowerFirst(ift.Field(i).Name)
+		}
 		switch val.Kind() {
 		case reflect.Struct:
 			// If the field is a struct the name of the field is appended

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,13 +14,16 @@ func TestConfig(t *testing.T) {
 		Console bool
 		Level   string
 		Name    string
+		Custom  string `mapstructure:"customTag"`
+		Env     string `mapstructure:"envTest"`
 	}
 	type Config struct {
 		Log Log
 	}
 
-	// example env var override
+	// example env var overrides
 	os.Setenv("TEST_LOG_LEVEL", "error")
+	os.Setenv("TEST_LOG_ENVTEST", "env")
 
 	// example flag override
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
@@ -41,15 +44,27 @@ func TestConfig(t *testing.T) {
 		t.Error(err)
 	}
 	if !c.Log.Verbose {
+		// value from default
 		t.Errorf("unexpected value for Log.Verbose; expected %t, got %t", true, c.Log.Verbose)
 	}
 	if !c.Log.Console {
+		// value from file by field name
 		t.Errorf("unexpected value for Log.Console; expected %t, got %t", true, c.Log.Console)
 	}
 	if c.Log.Level != "error" {
+		// value override with env var from field name `TEST_LOG_LEVEL`
 		t.Errorf("unexpected value for Log.Level; expected %s, got %s", "error", c.Log.Level)
 	}
 	if c.Log.Name != "blah" {
+		// value override with flag `--name`
 		t.Errorf("unexpected value for Log.Name; expected %s, got %s", "blah", c.Log.Name)
+	}
+	if c.Log.Custom != "value" {
+		// value from file by mapstructure tag
+		t.Errorf("unexpected value for Log.Custom; expected %s, got %s", "value", c.Log.Custom)
+	}
+	if c.Log.Env != "env" {
+		// value override with env var from mapstructure tag `TEST_LOG_ENVTEST`
+		t.Errorf("unexpected value for Log.Env; expected %s, got %s", "env", c.Log.Env)
 	}
 }

--- a/config/testdata/test.toml
+++ b/config/testdata/test.toml
@@ -2,3 +2,4 @@
 [log]
 console = true
 level = "info"
+customTag = "value"


### PR DESCRIPTION
Enable overriding field name for config with `mapstructure` tag.