### PR TITLE
feat(grpc): Healthcheck client request

### DIFF
--- a/grpc/health.go
+++ b/grpc/health.go
@@ -1,0 +1,55 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/rs/xid"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/metadata"
+
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// HealthRequest makes a healthcheck request to gRPC service
+func HealthRequest(host string, svc []string, reqIDField string, log zerolog.Logger) error {
+	cc, err := NewClient(host)
+	if err != nil {
+		return fmt.Errorf("cound not create gRPC client connection: %v", err)
+	}
+	hc := healthpb.NewHealthClient(cc)
+	var wg sync.WaitGroup
+	errC := make(chan error, 1)
+	for _, svc := range svc {
+		wg.Add(1)
+		go func(svc string) {
+			defer wg.Done()
+			requestID := xid.New().String()
+			l := log.With().Str(reqIDField, requestID).Logger()
+			md := metadata.Pairs(reqIDField, requestID)
+			ctx := metadata.NewOutgoingContext(context.Background(), md)
+			l.Debug().Msg("running healthceck")
+			rsp, err := hc.Check(ctx, &healthpb.HealthCheckRequest{
+				Service: svc,
+			})
+			switch err {
+			case nil:
+				l.Debug().
+					Str("service", svc).
+					Str("status", rsp.GetStatus().String()).
+					Msg("service status")
+				switch rsp.GetStatus() {
+				case healthpb.HealthCheckResponse_NOT_SERVING, healthpb.HealthCheckResponse_UNKNOWN:
+					errC <- fmt.Errorf("%s: not serving", svc)
+				}
+			default:
+				errC <- fmt.Errorf("cound not create gRPC client connection: %v", err)
+			}
+		}(svc)
+	}
+	wg.Wait()
+	close(errC)
+	err = <-errC
+	return err
+}

--- a/grpc/health_test.go
+++ b/grpc/health_test.go
@@ -1,0 +1,58 @@
+package grpc_test
+
+import (
+	"errors"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+
+	grpckit "go.soon.build/kit/grpc"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestHealthRequest(t *testing.T) {
+	testCases := []struct {
+		desc string
+		svc  []string
+		err  error
+	}{
+		{
+			desc: "success",
+			svc:  []string{"test"},
+		},
+		{
+			desc: "fail",
+			svc:  []string{"test", "unkown"},
+			err:  errors.New("cound not create gRPC client connection: rpc error: code = NotFound desc = unknown service"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			host := ":50000"
+			listener, err := net.Listen("tcp", host)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer listener.Close()
+			srv := grpc.NewServer()
+			defer srv.Stop()
+			hs := health.NewServer()
+			hs.SetServingStatus("test", healthpb.HealthCheckResponse_SERVING)
+			healthpb.RegisterHealthServer(srv, hs)
+			go func() {
+				_ = srv.Serve(listener)
+			}()
+			err = grpckit.HealthRequest(host, tc.svc, "requestID", zerolog.New(os.Stdout))
+			if tc.err == nil && err != nil {
+				t.Fatal(err)
+			}
+			if tc.err != nil && err.Error() != tc.err.Error() {
+				t.Errorf("unexpected err; expected %v, got %v", tc.err, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Still undecided whether its worthwhile for this to feature in the kit... we use it for the healthcheck CLI command in every gRPC service.  