### PR TITLE
feat(pubsub): Pass through gcloud client options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/docker/distribution v2.7.0+incompatible // indirect
 	github.com/docker/docker v1.13.1 // indirect
-	github.com/golang-migrate/migrate v3.5.4+incompatible
 	github.com/golang-migrate/migrate/v4 v4.2.1
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
+	github.com/lib/pq v1.0.0
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/rs/xid v1.2.1
 	github.com/rs/zerolog v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ github.com/go-ini/ini v1.39.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3I
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/gocql/gocql v0.0.0-20181012100315-44e29ed5b8a4/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang-migrate/migrate v3.5.4+incompatible h1:R7OzwvCJTCgwapPCiX6DyBiu2czIUMDCB118gFTKTUA=
-github.com/golang-migrate/migrate v3.5.4+incompatible/go.mod h1:IsVUlFN5puWOmXrqjgGUfIRIbU7mr8oNBE2tyERd9Wk=
 github.com/golang-migrate/migrate/v4 v4.2.1 h1:LfAwxzPCTdTr3ec3May3d93gE/oo4ljsxYzd7uuMW5U=
 github.com/golang-migrate/migrate/v4 v4.2.1/go.mod h1:Jg9FRUjqM7gthk1c8lSnSZlQ+2PL0rQEJQhVunIbwqA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
@@ -87,8 +85,10 @@ github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kshvakov/clickhouse v1.3.4/go.mod h1:DMzX7FxRymoNkVgizH0DWAL8Cur7wHLgx3MUnGwJqpE=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
@@ -197,6 +197,7 @@ google.golang.org/grpc v1.17.0 h1:TRJYBgMclJvGYn2rIMjj+h9KtMt5r1Ij7ODVRIZkwhk=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.39.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/pubsub/gcloud/gcloud.go
+++ b/pubsub/gcloud/gcloud.go
@@ -22,11 +22,10 @@ func (m *Message) Data() []byte {
 
 // Gcloud is an implementation of Publisher/Subscriber for Google Cloud Pubsub
 type Gcloud struct {
-	subName   string
-	projectID string
-	topic     *pubsub.Topic
-	client    *pubsub.Client
-	log       zerolog.Logger
+	subName string
+	topic   *pubsub.Topic
+	client  *pubsub.Client
+	log     zerolog.Logger
 }
 
 // Option configures a Gcloud instance
@@ -44,7 +43,6 @@ func WithLogger(log zerolog.Logger) Option {
 	return func(p *Gcloud) {
 		p.log = log.With().
 			Str("pkg", "pubsub").
-			Str("project", p.projectID).
 			Str("topic", p.topic.String()).
 			Logger()
 	}
@@ -52,24 +50,16 @@ func WithLogger(log zerolog.Logger) Option {
 
 // New sets up a Gcloud instance for Publish/Subscribing to a
 // Google Cloud Pubsub topic
-func New(ctx context.Context, project, topic string, opts ...Option) (*Gcloud, error) {
+func New(ctx context.Context, topic string, client *pubsub.Client, opts ...Option) (*Gcloud, error) {
 	log := zerolog.New(os.Stdout).With().
 		Str("pkg", "pubsub").
-		Str("project", project).
 		Str("topic", topic).
 		Logger()
-	// context for calling NewClient should not timeout
-	// https://godoc.org/cloud.google.com/go#hdr-Timeouts_and_Cancellation
-	client, err := pubsub.NewClient(ctx, project)
-	if err != nil {
-		return nil, err
-	}
 	p := &Gcloud{
-		subName:   "kit",
-		projectID: project,
-		client:    client,
-		topic:     client.Topic(topic),
-		log:       log,
+		subName: "kit",
+		client:  client,
+		topic:   client.Topic(topic),
+		log:     log,
 	}
 	for _, opt := range opts {
 		opt(p)

--- a/pubsub/gcloud/gcloud_test.go
+++ b/pubsub/gcloud/gcloud_test.go
@@ -7,10 +7,16 @@ import (
 	"testing"
 
 	"go.soon.build/kit/pubsub/gcloud"
+
+	"cloud.google.com/go/pubsub"
 )
 
 func TestPublishSubscribe(t *testing.T) {
-	p, err := gcloud.New(context.Background(), "kit-test", "test")
+	client, err := pubsub.NewClient(context.Background(), "kit-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := gcloud.New(context.Background(), "test", client)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Need to pass-through gcloud pubsub client options in order to configure credentials file etc. An alternative might be to move the gcloud client construction out of this func and just pass the client in 🤔 