### PR TITLE
feat(config): Read and merge all config files in a directory

### DIFF
--- a/config/testdata/test2.toml
+++ b/config/testdata/test2.toml
@@ -1,0 +1,2 @@
+[log]
+name = "test"


### PR DESCRIPTION
Adds the ability to read and merge all config files (toml) from a directory. Unfortunately viper doesn't offer a globbing pattern so we need to read the contents of the config directory manually. Also has a caveat that slices or maps wont be merged but rather overidden with the slice declared in the last file - see this [issue](https://github.com/spf13/viper/issues/462)