### PR TITLE
feat(config): Support env vars for projects with are hyphenated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11.4
+      - image: golang:1.19.4-buster
     steps:
       - checkout
       - run:
@@ -13,23 +13,18 @@ jobs:
           command: make download
   lint:
     docker:
-      - image: golangci/golangci-lint:v1.12.5
+      - image: golangci/golangci-lint:v1.50.0
     steps:
       - checkout
       - run:
-          command: |
-            export PATH=$(pwd)/bin:$PATH
-            make download
-            make lint
+          command: make lint
   test:
     docker:
-      - image: circleci/golang:1.11.4
+      - image: golang:1.19.4-buster
     steps:
       - checkout
       - run:
-          command: |
-            make download
-            make test
+          command: make test
 
 workflows:
   build_lint_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Golang CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-go/ for more details
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
@@ -11,12 +11,29 @@ jobs:
       - run:
           name: install dependencies
           command: make download
+  lint:
+    docker:
+      - image: golangci/golangci-lint:v1.12.5
+    steps:
+      - checkout
       - run:
-          name:  lint
           command: |
-            wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.12.5
             export PATH=$(pwd)/bin:$PATH
+            make download
             make lint
+  test:
+    docker:
+      - image: circleci/golang:1.11.4
+    steps:
+      - checkout
       - run:
-          name: test
-          command: make test
+          command: |
+            make download
+            make test
+
+workflows:
+  build_lint_test:
+    jobs:
+      - build
+      - lint
+      - test

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ download:
 .PHONY: test
 test:
 ifeq ("$(wildcard $(shell which gocov))","")
-	go get github.com/axw/gocov/gocov
+	go install github.com/axw/gocov/gocov@v1.1.0
 endif
 	@$(foreach module,$(MODULES),cd $(CWD)/$(module) && gocov test ./... | gocov report;)
 

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ func BindFlag(key string, flag *pflag.Flag) Option {
 // - TOML format
 // - Loads files from `/etc/name/name.toml`, `$HOME/.config/name.toml`
 // - Env vars as `NAME_FIELD`
+// - Names that are hyphenated will have the hyphens removed e.g. "new-project" would be accessed "NEWPROJECT"
 func ViperWithDefaults(name string) *viper.Viper {
 	v := viper.New()
 	v.SetConfigType("toml")
@@ -52,9 +53,7 @@ func ViperWithDefaults(name string) *viper.Viper {
 	// Set default config paths
 	v.AddConfigPath(fmt.Sprintf("/etc/%s", name))
 	v.AddConfigPath("$HOME/.config")
-	// Configure env var
-	v.SetEnvPrefix(name)
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	setEnv(v, name)
 	return v
 }
 
@@ -84,15 +83,14 @@ func ReadInConfig(v *viper.Viper, c interface{}, opts ...Option) error {
 // - TOML format
 // - Loads files from `/etc/name/`
 // - Env vars as `NAME_FIELD`
+// - Names that are hyphenated will have the hyphens removed e.g. "new-project" would be accessed "NEWPROJECT"
 func ViperWithDir(name string) (*viper.Viper, string) {
 	v := viper.New()
 	v.SetConfigType("toml")
 	// Set default config paths
 	path := fmt.Sprintf("/etc/%s", name)
 	v.AddConfigPath(path)
-	// Configure env var
-	v.SetEnvPrefix(name)
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	setEnv(v, name)
 	return v, path
 }
 
@@ -175,4 +173,10 @@ func bindEnvs(v *viper.Viper, iface interface{}, parts ...string) error {
 		}
 	}
 	return nil
+}
+
+func setEnv(v *viper.Viper, name string) {
+	envPrefix := strings.ReplaceAll(name, "-", "")
+	v.SetEnvPrefix(envPrefix)
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 }

--- a/grpc/go.sum
+++ b/grpc/go.sum
@@ -19,6 +19,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJV
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/http/http.go
+++ b/http/http.go
@@ -119,8 +119,7 @@ func (s *Server) Start(ctx context.Context) error {
 	case err := <-errC:
 		return err
 	case <-ctx.Done():
-		s.Stop()
-		return nil
+		return s.Stop()
 	}
 }
 


### PR DESCRIPTION
Most shells don't allow setting env vars with hyphens in which prevented env var values for projects with a hyphenated name. This removes the hyphen so test-project will look for env vars prefixed with TESTPROJECT