### PR TITLE
feat(grpc): allow specifying additional configuration options on dial

### DIFF
--- a/grpc/client.go
+++ b/grpc/client.go
@@ -8,13 +8,17 @@ import (
 )
 
 // NewClient constructs a grpc client connection
-func NewClient(server string) (*grpc.ClientConn, error) {
+func NewClient(server string, grpcOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	grpcOpts = append(grpcOpts,
+		// For backwards compatibility, keep these previous, hardcoded options
+		grpc.WithBlock(),
+		grpc.WithInsecure(), // Note: Deprecated in newer versions for grpc.WithTransportCredentials(insecure.NewCredentials())
+	)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	return grpc.DialContext(
 		ctx,
 		server,
-		grpc.WithInsecure(),
-		grpc.WithBlock(),
+		grpcOpts...,
 	)
 }


### PR DESCRIPTION
Related to the work on SRD-1061 (tracing and observability) we need the ability to add additional options into the Dial call when creating a new grpc client.

This should not be a breaking change despite the parameter list change.