### PR TITLE
tweak(tracing): rename StartSpan to Start so we implement the Tracer …

### DIFF
--- a/tracing/otel/provider.go
+++ b/tracing/otel/provider.go
@@ -30,6 +30,8 @@ type OtelProvider struct {
 	exporter sdktrace.SpanExporter
 }
 
+var _ trace.Tracer = &OtelProvider{}
+
 // Typical option function pattern
 type OtelProviderOption func(*OtelProvider) error
 
@@ -180,7 +182,7 @@ func (o *OtelProvider) SetupGlobalState(ctx context.Context) (CleanupFunc, error
 // and then uses it to start a new span.
 //
 // If you're interested in further details, please see the `Tracer.Start` function from the OTEL SDK.
-func (o *OtelProvider) StartSpan(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+func (o *OtelProvider) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return o.tracerFromContext(ctx).Start(ctx, spanName, opts...)
 }
 

--- a/tracing/otel/provider_test.go
+++ b/tracing/otel/provider_test.go
@@ -188,12 +188,12 @@ func TestGetTracerName(t *testing.T) {
 	assert.Equal(t, "service", provider.getTracerName())
 }
 
-func TestStartSpan(t *testing.T) {
+func TestStart(t *testing.T) {
 	providerMutex.Lock()
 	defer providerMutex.Unlock()
 	testExporter.Reset()
 
-	ctx, span := testProvider.StartSpan(context.Background(), "testSpan")
+	ctx, span := testProvider.Start(context.Background(), "testSpan")
 	assert.NotNil(t, ctx)
 	assert.True(t, span.IsRecording())
 	span.End()


### PR DESCRIPTION
…interface.

This is so we can more easily insert the otel SDK's standard No-op tracer into our testing code.