### PR TITLE
fix(tracing): Use just the traceID for gcp log linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ srv := grpc.NewServer(
 
 // linking logs to a span
 provider, err := NewOtelProvider("service-name",
-	otelkit.WithGCPTraceLogger("gcp-project-id"),
+	otelkit.WithGCPTraceLogger(),
 )
 ctx, span := s.tracer.Start(stream.Context(), "UpdateRedirects")
 defer span.End()

--- a/tracing/otel/helpers.go
+++ b/tracing/otel/helpers.go
@@ -2,7 +2,6 @@ package otel
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
@@ -34,7 +33,6 @@ var defaultGCPTraceLog = gcpTraceLog{
 type gcpTraceLog struct {
 	traceFieldName string
 	spanFieldName  string
-	gcpProjectID   string
 }
 
 // LogFromCtx returns a log from the provided context. It adds GCP trace and span fields so the log can be associated with cloud tracing
@@ -45,8 +43,8 @@ func (tl *gcpTraceLog) LogFromCtx(ctx context.Context) *zerolog.Logger {
 	if span.SpanContext().HasSpanID() {
 		fields[tl.spanFieldName] = span.SpanContext().SpanID()
 	}
-	if span.SpanContext().HasTraceID() && tl.gcpProjectID != "" {
-		fields[tl.traceFieldName] = fmt.Sprintf("projects/%s/traces/%s", tl.gcpProjectID, span.SpanContext().TraceID())
+	if span.SpanContext().HasTraceID() {
+		fields[tl.traceFieldName] = span.SpanContext().TraceID()
 	}
 	l := log.With().Fields(fields).Logger()
 	return &l

--- a/tracing/otel/helpers_test.go
+++ b/tracing/otel/helpers_test.go
@@ -30,21 +30,19 @@ func Test_gcpTraceLog_LogFromCtx(t *testing.T) {
 			gcpTraceLog: &gcpTraceLog{
 				traceFieldName: "traceFieldName",
 				spanFieldName:  "spanFieldName",
-				gcpProjectID:   "gcpProjectId",
 			},
 			args: args{
 				ctx: context.Background(),
 			},
 			traceID: testTraceID,
 			spanID:  testSpanID,
-			xLogs: `{"level":"info","spanFieldName":"0102030405060708","traceFieldName":"projects/gcpProjectId/traces/0102030405060708090a0b0c0d0e0f10"}
+			xLogs: `{"level":"info","spanFieldName":"0102030405060708","traceFieldName":"0102030405060708090a0b0c0d0e0f10"}
 `,
 		},
 		"not add traceID if it doesn't exist": {
 			gcpTraceLog: &gcpTraceLog{
 				traceFieldName: "traceFieldName",
 				spanFieldName:  "spanFieldName",
-				gcpProjectID:   "gcpProjectId",
 			},
 			args: args{
 				ctx: context.Background(),
@@ -58,28 +56,13 @@ func Test_gcpTraceLog_LogFromCtx(t *testing.T) {
 			gcpTraceLog: &gcpTraceLog{
 				traceFieldName: "traceFieldName",
 				spanFieldName:  "spanFieldName",
-				gcpProjectID:   "gcpProjectId",
 			},
 			args: args{
 				ctx: context.Background(),
 			},
 			traceID: testTraceID,
 			spanID:  "",
-			xLogs: `{"level":"info","traceFieldName":"projects/gcpProjectId/traces/0102030405060708090a0b0c0d0e0f10"}
-`,
-		},
-		"not add traceID if it gcp project doesn't exist": {
-			gcpTraceLog: &gcpTraceLog{
-				traceFieldName: "traceFieldName",
-				spanFieldName:  "spanFieldName",
-				gcpProjectID:   "",
-			},
-			args: args{
-				ctx: context.Background(),
-			},
-			traceID: testTraceID,
-			spanID:  testSpanID,
-			xLogs: `{"level":"info","spanFieldName":"0102030405060708"}
+			xLogs: `{"level":"info","traceFieldName":"0102030405060708090a0b0c0d0e0f10"}
 `,
 		},
 	}

--- a/tracing/otel/provider.go
+++ b/tracing/otel/provider.go
@@ -114,10 +114,9 @@ func WithTracerProviderOptions(opts ...sdktrace.TracerProviderOption) OtelProvid
 }
 
 // Sets the trace logger to use GCP
-func WithGCPTraceLogger(gcpProject string) OtelProviderOption {
+func WithGCPTraceLogger() OtelProviderOption {
 	return func(op *OtelProvider) error {
 		tl := &defaultGCPTraceLog
-		tl.gcpProjectID = gcpProject
 		op.getTraceLogger = tl
 		return nil
 	}


### PR DESCRIPTION
It seems GCP was gaslighting me last week. Despite the docs saying you need to provide the fully qualified trace ID `projects/PROJECT_ID/traces/TRACE_ID` that actually gets truncated in logging to this `trace: "projects/soon-cms-dev/traces/952"` see this [log entry](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-09-25T08:50:04.078667237Z;duration=P7D;query=resource.labels.container_name%3D%22proxy-config-server%22%0A-labels.%22k8s-pod%2Fapp_kubernetes_io%2Fname%22%3D%22proxy-config-server-upstream%22%0A-jsonPayload.%22grpc.method%22%3D%22%2Fgrpc.health.v1.Health%2FCheck%22%0Atimestamp%3D%222023-09-25T08:50:04.077819999Z%22%0AinsertId%3D%22lo6ftygzuaxxvqrg%22?project=soon-cms-dev) I could have sworn this was working correctly last week but it stopped working on Friday. After a bit of trail and error I found that just setting the trace field to the trace id was sufficient. Somewhere in the log collector it must be automatically adding the project context as now the log field appears correctly `trace: "projects/soon-cms-dev/traces/d3ca1aec56d3ccc4ba660ae66df5bc57"` (see this [log entry](https://console.cloud.google.com/logs/query;cursorTimestamp=2023-09-25T10:20:05.238677121Z;duration=P7D;query=resource.labels.container_name%3D%22proxy-config-server%22%0A-labels.%22k8s-pod%2Fapp_kubernetes_io%2Fname%22%3D%22proxy-config-server-upstream%22%0A-jsonPayload.%22grpc.method%22%3D%22%2Fgrpc.health.v1.Health%2FCheck%22%0Atimestamp%3D%222023-09-25T10:20:05.238677121Z%22%0AinsertId%3D%226sbwnbjmpd3mvpdu%22?project=soon-cms-dev)) See [this trace](https://console.cloud.google.com/traces/list?referrer=search&project=soon-cms-dev&tid=8510e118c9dcf2ea8c4d7ffd9cb96fcc) for proof that it's working now