### PR TITLE
fix(tracing): remove the hard coded AlwaysSample sampler

### DIFF
--- a/tracing/otel/provider.go
+++ b/tracing/otel/provider.go
@@ -175,7 +175,6 @@ func (o *OtelProvider) SetupGlobalState(ctx context.Context) (CleanupFunc, error
 	opts := append(
 		o.tracerProviderOptions,
 		sdktrace.WithBatcher(o.exporter),
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithResource(res),
 	)
 	provider := sdktrace.NewTracerProvider(opts...)


### PR DESCRIPTION
Most of the context is in SRD-1515.

I'm not even entirely sure why I added this in the first place; but I remember struggling to get traces with the default settings, however I've confirmed locally it all works fine.

This then allows the SDK to make use of the standard OTEL env vars which we can configure per cluster (defaulting to always sample if we don't give explicit config).