### PR TITLE
feat(httpkit): add filtering to http logging

### DIFF
--- a/http/middleware.go
+++ b/http/middleware.go
@@ -28,12 +28,18 @@ var DefaultRequestLogger = func(log zerolog.Logger, fieldKey, headerName string)
 		return hlog.NewHandler(log)(
 			AccessHandler(
 				RequestIDHandler(fieldKey, headerName)(next),
-				func(r *http.Request) bool {
-					return r.URL.Path == "/" || strings.HasPrefix(r.URL.Path, "/__")
-				},
+				DefaultLogFilter,
 			),
 		)
 	}
+}
+
+// The filter used by the DefaultRequestLogger.
+//
+// Generally this will try to filter out really common endpoints, such as the root
+// and health check endpoints.
+var DefaultLogFilter = func(r *http.Request) bool {
+	return r.URL.Path == "/" || strings.HasPrefix(r.URL.Path, "/__")
 }
 
 // AccessHandler is a standard request logger implementation


### PR DESCRIPTION
This **P**R:

* Adds an extra parameter to `AccessHandler` that allows you to specify filters.
* Makes the `DefaultRequestLogger` add a filter to prevent logging out `/` and any path starting with `/__` - this should hopefully cull most of our health checks without any further changes.

The parameter to `AccessHandler` was made variadic so that there's no breaking change. It could spell trouble if we were to ever extend that function further though, but my logic is that would probably be a breaking change by itself anyway.