### PR TITLE
refator(tracing): Disable BatchWriteSpan in exporter setup

### DIFF
--- a/tracing/go.mod
+++ b/tracing/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/otel v1.21.0
 	go.opentelemetry.io/otel/sdk v1.21.0
 	go.opentelemetry.io/otel/trace v1.21.0
+	google.golang.org/api v0.140.0
 	google.golang.org/grpc v1.58.0
 )
 
@@ -41,7 +42,6 @@ require (
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
-	google.golang.org/api v0.140.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20230911183012-2d3300fd4832 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230911183012-2d3300fd4832 // indirect


### PR DESCRIPTION
### MR Overview
This merge requests updates `.WithGcpExporterAndOptions()` to disable the default telemetry (OpenCensus)
settings on gRPC and HTTP clients (the reason `BatchWriteSpans` trace was being spammed).

**Overview of Changes**
* Updates exporter init so that it doesn't have to be set on every service
* Example implementation:
```go
// old method
return otelkit.WithGcpExporterAndOptions(
	gcpexporter.WithProjectID(cfg.Events.GooglePubSub.Project),
	gcpexporter.WithTraceClientOptions(
		[]option.ClientOption{
			option.WithCredentialsFile(cfg.Events.GooglePubSub.JWT),
			option.WithTelemetryDisabled(),
		},
	),
), nil

// new method
tracingClientOpts := []option.ClientOption{
	option.WithCredentialsFile(cfg.Events.GooglePubSub.JWT),
},
return otelkit.WithGcpExporterAndOptions(
	tracingClientOpts,
	gcpexporter.WithProjectID(cfg.Events.GooglePubSub.Project),
), nil
```

Closes SOON-388