### PR TITLE
feat(tracing/otel): Add methods to filter rpcs in otelconnect

### DIFF
--- a/tracing/go.mod
+++ b/tracing/go.mod
@@ -24,6 +24,8 @@ require (
 	cloud.google.com/go/logging v1.9.0 // indirect
 	cloud.google.com/go/monitoring v1.18.0 // indirect
 	cloud.google.com/go/trace v1.10.5 // indirect
+	connectrpc.com/connect v1.16.2 // indirect
+	connectrpc.com/otelconnect v0.7.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.19.1 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.46.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/tracing/go.sum
+++ b/tracing/go.sum
@@ -12,6 +12,10 @@ cloud.google.com/go/monitoring v1.18.0 h1:NfkDLQDG2UR3WYZVQE8kwSbUIEyIqJUPl+aOQd
 cloud.google.com/go/monitoring v1.18.0/go.mod h1:c92vVBCeq/OB4Ioyo+NbN2U7tlg5ZH41PZcdvfc+Lcg=
 cloud.google.com/go/trace v1.10.5 h1:0pr4lIKJ5XZFYD9GtxXEWr0KkVeigc3wlGpZco0X1oA=
 cloud.google.com/go/trace v1.10.5/go.mod h1:9hjCV1nGBCtXbAE4YK7OqJ8pmPYSxPA0I67JwRd5s3M=
+connectrpc.com/connect v1.16.2 h1:ybd6y+ls7GOlb7Bh5C8+ghA6SvCBajHwxssO2CGFjqE=
+connectrpc.com/connect v1.16.2/go.mod h1:n2kgwskMHXC+lVqb18wngEpF95ldBHXjZYJussz5FRc=
+connectrpc.com/otelconnect v0.7.0 h1:ZH55ZZtcJOTKWWLy3qmL4Pam4RzRWBJFOqTPyAqCXkY=
+connectrpc.com/otelconnect v0.7.0/go.mod h1:Bt2ivBymHZHqxvo4HkJ0EwHuUzQN6k2l0oH+mp/8nwc=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.19.1 h1:LyRJCTBJP53P1JURFbhFSRz36gxaBtMAjzjlYupNR7Q=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.19.1/go.mod h1:Xx0VKh7GJ4si3rmElbh19Mejxz68ibWg/J30ZOMrqzU=

--- a/tracing/otel/interceptors_test.go
+++ b/tracing/otel/interceptors_test.go
@@ -1,8 +1,10 @@
 package otel
 
 import (
+	"context"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc/stats"
@@ -44,44 +46,96 @@ func TestFilterChain(t *testing.T) {
 	}
 }
 
-func TestFilterMethods(t *testing.T) {
-	cases := map[string]struct {
-		info    *stats.RPCTagInfo
-		methods []string
-		expect  bool
-	}{
-		"empty should default to being traced": {
-			info:    &stats.RPCTagInfo{},
-			methods: []string{},
-			expect:  true,
-		},
-		"matches on StreamServerInfo should work": {
-			info: &stats.RPCTagInfo{
-				FullMethodName: "/abc.Service/Method",
-			},
-			methods: []string{"/abc.Service/Method"},
-			expect:  false,
-		},
-		"matches on UnaryServerInfo should work": {
-			info: &stats.RPCTagInfo{
-				FullMethodName: "/abc.Service/Method",
-			},
-			methods: []string{"/abc.Service/Method"},
-			expect:  false,
-		},
-		"matches on Method should work": {
-			info: &stats.RPCTagInfo{
-				FullMethodName: "/abc.Service/Method",
-			},
-			methods: []string{"/abc.Service/Method"},
-			expect:  false,
-		},
-	}
+type method string
 
-	for name, testCase := range cases {
+func (method method) ConnectMethod() connect.Spec {
+	if string(method) == "" {
+		return connect.Spec{}
+	}
+	return connect.Spec{
+		Procedure: string(method),
+	}
+}
+
+func (method method) GRPCMethod() *stats.RPCTagInfo {
+	if string(method) == "" {
+		return &stats.RPCTagInfo{}
+	}
+	return &stats.RPCTagInfo{
+		FullMethodName: string(method),
+	}
+}
+
+type filterMethodTestCase map[string]struct {
+	method  method
+	methods []string
+	expect  bool
+}
+
+var filterMethodTests = filterMethodTestCase{
+	"empty should default to being traced": {
+		method:  method(""),
+		methods: []string{},
+		expect:  true,
+	},
+	"matches on StreamServerInfo should work": {
+		method:  method("/abc.Service/Method"),
+		methods: []string{"/abc.Service/Method"},
+		expect:  false,
+	},
+	"matches on Method should work": {
+		method:  method("/abc.Service/Method"),
+		methods: []string{"/abc.Service/Method"},
+		expect:  false,
+	},
+}
+
+func TestFilterMethods(t *testing.T) {
+	for name, testCase := range filterMethodTests {
 		t.Run(name, func(t *testing.T) {
 			filter := FilterMethods(testCase.methods...)
-			result := filter(testCase.info)
+			result := filter(testCase.method.GRPCMethod())
+			assert.Equal(t, testCase.expect, result)
+		})
+	}
+}
+
+func TestFilterMethodsConnect(t *testing.T) {
+	for name, testCase := range filterMethodTests {
+		t.Run(name, func(t *testing.T) {
+			filter := FilterMethodsConnect(testCase.methods...)
+			result := filter(context.Background(), testCase.method.ConnectMethod())
+			assert.Equal(t, testCase.expect, result)
+		})
+	}
+}
+
+func TestFilterMethodsConnectWithHealthCheck(t *testing.T) {
+	tests := map[string]struct {
+		method            method
+		additionalMethods []string
+		expect            bool
+	}{
+		"filter healthcheck - no additional methods": {
+			method:            "/grpc.health.v1.Health/Check",
+			additionalMethods: []string{},
+			expect:            false,
+		},
+		"filter healthcheck - with additional methods": {
+			method:            "/grpc.health.v1.Health/Check",
+			additionalMethods: []string{"/abc.Service/Method"},
+			expect:            false,
+		},
+		"filter additional method": {
+			method:            "/abc.Service/Method",
+			additionalMethods: []string{"/abc.Service/Method"},
+			expect:            false,
+		},
+	}
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			filter := FilterMethodsConnectWithHealthCheck(testCase.additionalMethods...)
+			result := filter(context.Background(), testCase.method.ConnectMethod())
 			assert.Equal(t, testCase.expect, result)
 		})
 	}


### PR DESCRIPTION
Adds methods for filter connectrpc requests from tracing. 

```go 
traceInterceptor, err := otelconnect.NewInterceptor(
    otelconnect.WithFilter(
        otelkit.FilterMethodsConnect("/grpc.health.v1.Health/Check"),
    ),
)

```
as filtering for grpc healthcheck is common I've added a function to include that by default
```go 
traceInterceptor, err := otelconnect.NewInterceptor(
    otelconnect.WithFilter(
        otelkit.FilterMethodsConnectWithHealthCheck(),
    ),
)
```