### PR TITLE
feat(pubsub): Add attributes to messages

### DIFF
--- a/pubsub/gcloud/gcloud.go
+++ b/pubsub/gcloud/gcloud.go
@@ -22,6 +22,11 @@ func (m *Message) Data() []byte {
 	return m.Message.Data
 }
 
+// Attributes returns the message attributes
+func (m *Message) Attrs() map[string]string {
+	return m.Message.Attributes
+}
+
 // Returns a new context that is enriched by the propagator passed during
 // the pubsub client's construction.
 func (m *Message) EnrichContext(ctx context.Context) context.Context {
@@ -97,10 +102,12 @@ func New(ctx context.Context, topic string, client *pubsub.Client, opts ...Optio
 // on a Google Cloud Pubsub topic.
 //
 // The client's propagator will be used to inject attributes into the message.
-func (p *Gcloud) Publish(ctx context.Context, data []byte) error {
+func (p *Gcloud) Publish(ctx context.Context, data []byte, attributes map[string]string) error {
 	p.log.Debug().Msg("publishing message")
 
-	attributes := make(map[string]string)
+	if attributes == nil {
+		attributes = make(map[string]string)
+	}
 	p.propagator.Inject(ctx, propagation.MapCarrier(attributes))
 
 	p.topic.Publish(ctx, &pubsub.Message{
@@ -112,10 +119,12 @@ func (p *Gcloud) Publish(ctx context.Context, data []byte) error {
 
 // PublishUntilComplete is similar to Publish, but is a blocking call as it uses `.Get()`,
 // it will also return any error that occurs
-func (p *Gcloud) PublishUntilComplete(ctx context.Context, data []byte) error {
+func (p *Gcloud) PublishUntilComplete(ctx context.Context, data []byte, attributes map[string]string) error {
 	p.log.Debug().Msg("publishing message until complete")
 
-	attributes := make(map[string]string)
+	if attributes == nil {
+		attributes = make(map[string]string)
+	}
 	p.propagator.Inject(ctx, propagation.MapCarrier(attributes))
 
 	_, err := p.topic.Publish(ctx, &pubsub.Message{

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -9,6 +9,7 @@ import (
 // A Message is a pubsub message to be consumed by a Worker
 type Message interface {
 	Data() []byte
+	Attrs() map[string]string
 	Ack()
 	Nack()
 	EnrichContext(context.Context) context.Context
@@ -16,13 +17,13 @@ type Message interface {
 
 // A Publisher takes some data and publishes it on a topic
 type Publisher interface {
-	Publish(context.Context, []byte) error
+	Publish(context.Context, []byte, map[string]string) error
 }
 
 // A CompletePublisher takes some data and publishes it on a topic
 // and returns errors, if any
 type CompletePublisher interface {
-	PublishUntilComplete(context.Context, []byte) error
+	PublishUntilComplete(context.Context, []byte, map[string]string) error
 }
 
 // A Subscriber streams a channel of Message


### PR DESCRIPTION
To process shopify messages we need to be able to extract attributes from the message to get at the metadata that shopify sends. 